### PR TITLE
chore(deps): bump openssl and rustls-webpki to patched versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -839,9 +839,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -871,9 +871,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -1047,7 +1047,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1074,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1321,7 +1321,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves all 9 open Dependabot alerts on `main` by bumping two transitive dependencies in `Cargo.lock`.

## Updates

| Crate | From | To | Alerts cleared |
|---|---|---|---|
| openssl | 0.10.75 | 0.10.78 | 5 (4 high, 1 low) |
| openssl-sys | 0.9.111 | 0.9.114 | — |
| rustls-webpki | 0.103.9 | 0.103.13 | 4 (1 high, 1 med, 2 low) |

## Alerts addressed

- GHSA-ghm9-cr32-g9qj — rust-openssl: `MdCtxRef::digest_final()` writes past caller buffer (high)
- GHSA-hppc-g8h3-xhp3 — rust-openssl: unchecked callback length in PSK/cookie trampolines (high)
- GHSA-8c75-8mhr-p7r9 — rust-openssl: incorrect bounds assertion in aes key wrap (high)
- GHSA-pqf5-4pqq-29f5 — rust-openssl: `Deriver::derive` overflow on OpenSSL 1.1.1 (high)
- GHSA-xmgf-hq76-4vx2 — rust-openssl: out-of-bounds read in PEM password callback (low)
- GHSA-82j2-j2ch-gfr8 — rustls-webpki: DoS via panic on malformed CRL BIT STRING (high)
- GHSA-pwjx-qhcg-rvj4 — webpki: CRL distribution point matching (medium)
- GHSA-xgp8-3hg3-c2mh — webpki: name constraints accepted for wildcard certs (low)
- GHSA-965h-392x-2mh5 — webpki: incorrect URI name constraints (low)

## Validation

- `cargo build` — clean
- `cargo test` — 179 passed
- `cargo clippy -- -D warnings` — no warnings
- `cargo fmt --check` — clean

## Notes

Supersedes Dependabot PR #106 (which only bumped `rustls-webpki` to 0.103.10 — partial fix).