### PR TITLE
docs(specs): reconcile errata from spec-vs-implementation audit

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,10 +1,10 @@
 # Implementation Plan
 
-Phase 1: 9/9 complete. Phase 2: 5/5 complete. Pre-existing bugs: 4/4 fixed. Tool hardening: 3/3 fixed. Schema fix: 1/1 fixed. Release fixes: 2/2 fixed. SSE error fix: 1/1 fixed. Test coverage gaps: 15/15 fixed. 179 tests pass, clippy clean, fmt clean.
+Phase 1: 10/10 complete. Phase 2: 5/5 complete. Pre-existing bugs: 4/4 fixed. Tool hardening: 3/3 fixed. Schema fix: 1/1 fixed. Release fixes: 2/2 fixed. SSE error fix: 1/1 fixed. Test coverage gaps: 15/15 fixed. 179 tests pass, clippy clean, fmt clean.
 
 All planned work is complete.
 
-Updated 2026-03-12: Full spec-vs-implementation audit across all 16 specs. Three gaps found and fixed: (1) release workflow missing `--latest` flag (spec R4, v0.0.16); (2) actions/checkout SHA mismatch between ci.yml and release.yml (spec R6, v0.0.16); (3) unknown SSE error types classified as permanent instead of transient (api-retry spec R1, v0.0.17).
+Updated 2026-03-12: Full spec-vs-implementation audit across all 15 feature specs (16 files including the index). Three gaps found and fixed: (1) release workflow missing `--latest` flag (spec R4, v0.0.16); (2) actions/checkout SHA mismatch between ci.yml and release.yml (spec R6, v0.0.16); (3) unknown SSE error types classified as permanent instead of transient (api-retry spec R1, v0.0.17).
 
 Updated 2026-03-12: Second audit pass found two test coverage gaps in parallel dispatch path. Both fixed in v0.0.19: (1) null-input tool_use in parallel path — test verifies error ToolResult produced and post-hooks skipped via blocked_flags; (2) mid-batch threshold trip — test verifies already-spawned futures joined, threshold_tripped set, and empty result returned.
 
@@ -38,15 +38,18 @@ Full line-by-line audit of all specs against implementation. Results:
 
 - `classify_error` for `AgentError::Api(reqwest::Error)` timeout/connect branches: constructing a `reqwest::Error` requires actual network failures. The error classification logic is correct by inspection, but these specific branches have no unit test. Accepted constraint — not worth introducing a mock HTTP layer for two match arms.
 
-- `coding-agent.md` R4 lists `Glob(path?, recursive?)` — `recursive` parameter not implemented. The `glob` crate handles `**` patterns natively, making an explicit parameter redundant. The model uses `**/*.rs` directly.
-- `coding-agent.md` R4 lists `Bash(command, cwd?)` — `cwd` parameter not implemented. The model uses `cd dir && command` pattern. Claude Code itself omits this parameter.
 - Bash schema declares a `description` parameter that `bash_exec` never reads. Harmless — the model sends it for context but the tool ignores it. Not worth removing since it serves as documentation in the schema.
 
 ## Spec Errata
 
-- `release-workflow.md` line 77: success criteria says "working `agent` binary" — should say `forgeflare`.
-- `session-capture.md` JSONL example (line 101): uses snake_case `read_file` in tool_use name. Should be PascalCase `Read` per `tool-name-compliance.md`.
-- `glob-shell-injection.md` R2: said "filesystem order (platform-dependent)" — corrected to "alphabetical order" (v0.0.21).
+All previously tracked errata have been reconciled in the source specs (2026-04-28). Historical entries:
+
+- `coding-agent.md` R4 `Glob(path?, recursive?)` and `Bash(command, cwd?)` — the optional parameters were never implemented. Spec updated to drop them and document why inline.
+- `coding-agent.md` "Reference: Go Source" section and `/reference/go-source/` pin — removed (reference directory no longer exists; Rust implementation is the source of truth).
+- `release-workflow.md` success criteria — `agent` binary name corrected to `forgeflare`.
+- `session-capture.md` JSONL example — snake_case `read_file` corrected to PascalCase `Read` per `tool-name-compliance.md`.
+- `sse-buffer-optimization.md` success criteria — enumerated test list (originally 6) replaced with a non-enumerated criterion to prevent drift as the SSE test suite grows.
+- `glob-shell-injection.md` R2: "filesystem order (platform-dependent)" corrected to "alphabetical order" (v0.0.21).
 
 ## Minor Code Observations (not blocking)
 

--- a/specs/coding-agent.md
+++ b/specs/coding-agent.md
@@ -36,11 +36,11 @@ tools! {
 - Tool schemas are sent with every API request, providing introspection natively
 - Macro generates schemas; dispatch is hand-written to support per-tool signatures (bash streaming)
 
-**R4. Five Tools**
-1. **Read** — Read(path) → file contents (handle binary, size limits)
-2. **Glob** — Glob(pattern) → [files]. The `glob` crate handles `**` natively, so no explicit `recursive` flag — the model uses `**/*.rs` directly.
+**R4. Five Tools** (argument names are the JSON keys sent by the model)
+1. **Read** — Read(file_path) → file contents (handle binary, size limits)
+2. **Glob** — Glob(pattern, path?) → [files]. `pattern` is the glob (e.g. `**/*.rs`), `path` is an optional base directory (default: cwd). The `glob` crate handles `**` natively, so no explicit `recursive` flag.
 3. **Bash** — Bash(command) → stdout/stderr (timeout, streaming output via callback). No `cwd` parameter — the model uses `cd dir && command` (matches Claude Code conventions).
-4. **Edit** — Edit(path, old_str, new_str, replace_all?) → success/error (exact match by default; replace_all=true for bulk changes; empty old_str on missing file = create with mkdir, empty old_str on existing file = append)
+4. **Edit** — Edit(file_path, old_str, new_str, replace_all?) → success/error (exact match by default; replace_all=true for bulk changes; empty old_str on missing file = create with mkdir, empty old_str on existing file = append)
 5. **Grep** — Grep(pattern, path?, file_type?, case_sensitive?) → matches (shell out to `rg`)
 
 **R5. CLI Interface**

--- a/specs/coding-agent.md
+++ b/specs/coding-agent.md
@@ -6,7 +6,6 @@ created: 2026-02-14
 # Unified Rust Coding Agent Specification
 
 **Target:** Single binary, streaming, subagent-aware, <950 production lines
-**Pin:** Go source at `/reference/go-source/` — pattern-match against working code
 
 ---
 
@@ -27,8 +26,8 @@ created: 2026-02-14
 ```rust
 // tools! macro generates all_tool_schemas() from one definition
 tools! {
-    "read_file", "Read a file", schema;
-    "list_files", "List files", schema;
+    "Read", "Read a file", schema;
+    "Glob", "List files matching a pattern", schema;
     // ...
 }
 // dispatch_tool() is hand-written — bash gets streaming callback, others don't
@@ -39,8 +38,8 @@ tools! {
 
 **R4. Five Tools**
 1. **Read** — Read(path) → file contents (handle binary, size limits)
-2. **Glob** — Glob(path?, recursive?) → [files]
-3. **Bash** — Bash(command, cwd?) → stdout/stderr (timeout, streaming output via callback)
+2. **Glob** — Glob(pattern) → [files]. The `glob` crate handles `**` natively, so no explicit `recursive` flag — the model uses `**/*.rs` directly.
+3. **Bash** — Bash(command) → stdout/stderr (timeout, streaming output via callback). No `cwd` parameter — the model uses `cd dir && command` (matches Claude Code conventions).
 4. **Edit** — Edit(path, old_str, new_str, replace_all?) → success/error (exact match by default; replace_all=true for bulk changes; empty old_str on missing file = create with mkdir, empty old_str on existing file = append)
 5. **Grep** — Grep(pattern, path?, file_type?, case_sensitive?) → matches (shell out to `rg`)
 
@@ -78,10 +77,7 @@ src/
   main.rs         — CLI, loop, error handling
   api.rs          — Anthropic client (reqwest + SSE)
   tools/
-    mod.rs        — All 5 tools with tools! macro (read, list, bash, edit, search)
-
-reference/
-  go-source/      — Cloned Go workshop code (pin)
+    mod.rs        — All 5 tools with tools! macro (Read, Glob, Bash, Edit, Grep)
 ```
 
 ---
@@ -143,17 +139,3 @@ reference/
 - code_search surfaces actionable error when rg (ripgrep) is not installed instead of cryptic "No such file" OS error
 - Bash streaming: channel-based output streaming via mpsc channels + 50ms polling loop. Reader threads send 4KB chunks, polling loop drains and forwards to caller callback. Partial output preserved on timeout. Eliminates wait-timeout dependency (replaced by try_wait + Instant deadline)
 - edit_file replace_all: optional boolean parameter for bulk replacements. Default false preserves single-match safety. Error message hints at replace_all when duplicates found
-
----
-
-## Reference: Go Source
-
-The Go workshop (`reference/go-source/`) contains 6 progressive versions:
-- `chat.go` — bare event loop
-- `read.go` — +read_file tool
-- `list_files.go` — +list_files tool
-- `bash_tool.go` — +bash tool
-- `edit_tool.go` — +edit_file tool
-- `code_search_tool.go` — +code_search tool
-
-Study the event loop in `edit_tool.go` (lines 126-214) as the canonical loop pattern. The Rust implementation should follow the same structure: API call → check response → dispatch tools → send results → repeat.

--- a/specs/release-workflow.md
+++ b/specs/release-workflow.md
@@ -78,7 +78,7 @@ File: `.github/workflows/release.yml` (separate from `ci.yml`)
 - [ ] macOS aarch64 binary compiles and tests pass on Apple Silicon runner
 - [ ] Linux x86_64 binary compiles and tests pass on Ubuntu runner
 - [ ] Both tarballs attached to GitHub Release
-- [ ] Tarball extracts to a working `agent` binary on target platform
+- [ ] Tarball extracts to a working `forgeflare` binary on target platform
 - [ ] Release blocked if CI (lint, audit, test) fails
 - [ ] No release artifacts published on build failure
 - [ ] Action SHAs pinned, permissions least-privilege

--- a/specs/session-capture.md
+++ b/specs/session-capture.md
@@ -102,7 +102,7 @@ User turn:
 Assistant turn with tool use:
 
 ```json
-{"type":"assistant","sessionId":"2026-02-10-uuid","uuid":"turn-uuid","parentUuid":"prev-uuid","timestamp":"2026-02-10T23:31:05Z","cwd":"/path/to/project","version":"0.0.44","message":{"role":"assistant","content":[{"type":"text","text":"Let me read that file."},{"type":"tool_use","id":"toolu_01X","name":"read_file","input":{"path":"src/main.rs"}}],"usage":{"input_tokens":1200,"output_tokens":350,"cache_creation_input_tokens":0,"cache_read_input_tokens":800}}}
+{"type":"assistant","sessionId":"2026-02-10-uuid","uuid":"turn-uuid","parentUuid":"prev-uuid","timestamp":"2026-02-10T23:31:05Z","cwd":"/path/to/project","version":"0.0.44","message":{"role":"assistant","content":[{"type":"text","text":"Let me read that file."},{"type":"tool_use","id":"toolu_01X","name":"Read","input":{"path":"src/main.rs"}}],"usage":{"input_tokens":1200,"output_tokens":350,"cache_creation_input_tokens":0,"cache_read_input_tokens":800}}}
 ```
 
 Tool result (part of next user turn):

--- a/specs/sse-buffer-optimization.md
+++ b/specs/sse-buffer-optimization.md
@@ -76,13 +76,7 @@ Changes to existing code:
 ## Success Criteria
 
 - [ ] No `.to_string()` calls on buffer slices in the SSE event extraction loop
-- [ ] All 6 existing SSE parser tests pass unchanged
-- [ ] `parse_sse_text_response` — text streaming and block assembly
-- [ ] `parse_sse_tool_use_response` — tool input JSON accumulation
-- [ ] `parse_sse_error_event_transient` — overloaded_error handling
-- [ ] `parse_sse_error_event_permanent` — invalid_request_error handling
-- [ ] `parse_sse_missing_stop_reason` — connection drop detection
-- [ ] `parse_sse_usage_from_message_start_and_delta` — cache token parsing
+- [ ] All existing SSE parser tests pass unchanged (text response, tool use accumulation, error events, missing stop_reason, usage parsing, and edge cases)
 - [ ] `cargo clippy -- -D warnings` clean
 
 ---


### PR DESCRIPTION
Reconciles all tracked errata from the IMPLEMENTATION_PLAN audit history into the source spec files. Single source of truth — errata stop accumulating in IMPLEMENTATION_PLAN, the specs themselves match implementation.

## Changes

**`specs/coding-agent.md`** — biggest cleanup
- Removed the `**Pin:** Go source at /reference/go-source/` header — the reference directory was deleted long ago
- Removed the entire \"Reference: Go Source\" section listing the 6 Go workshop files (`chat.go`, `read.go`, etc.) — historical scaffolding from initial port
- Updated R3 macro example tool names (`read_file` → `Read`, `list_files` → `Glob`) to match `tool-name-compliance.md`
- Updated R4 to drop never-implemented optional parameters (`Glob` `recursive`, `Bash` `cwd`) and document why inline instead of in IMPLEMENTATION_PLAN
- Updated architecture tree: removed `reference/go-source/`; updated `tools/mod.rs` parenthetical to PascalCase tool names

**`specs/release-workflow.md`** — line 81 success criterion: \`agent\` binary → \`forgeflare\`

**`specs/session-capture.md`** — JSONL example tool_use \`name\`: \`read_file\` → \`Read\`

**`specs/sse-buffer-optimization.md`** — replaced enumerated 6-test list with a single non-enumerated criterion (test suite has grown to 10; enumeration just drifts)

**`IMPLEMENTATION_PLAN.md`** — Phase 1 count `9/9` → `10/10`; clarified \"all 16 specs\" to \"15 feature specs (16 files including index)\"; condensed Spec Errata section to a historical record now that all entries are reconciled in their source specs

## Validation

- \`cargo build\` — clean
- \`cargo test\` — 179 passed
- \`cargo clippy -- -D warnings\` — no warnings
- \`cargo fmt --check\` — clean

(No code changes; validation just confirms doc-only edits don't disturb the build graph via include_str! or similar.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated specification docs with clarified tool naming and usage examples.
  * Aligned release artifact reference in release workflow checks.
  * Consolidated implementation tracking and audit entries into a reconciled historical errata list.
  * Simplified success-criteria language for streaming/buffer tests and harmonized related examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->